### PR TITLE
Adding Unraid 6.12.x support

### DIFF
--- a/openVMTools_compiled.plg
+++ b/openVMTools_compiled.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name "openVMTools_compiled">
 <!ENTITY author "StevenD">
-<!ENTITY version "2022.11.18">
+<!ENTITY version "2023.02.28">
 <!ENTITY source "/boot/config/plugins/&name;/packages">
 <!ENTITY plugdir "/usr/local/emhttp/plugins/&name;">
 <!ENTITY repo "https://raw.githubusercontent.com/StevenDTX/unRAID-open-vm-tools/master/packages">
@@ -13,6 +13,11 @@
 
 <CHANGES>
 ##&name;
+
+###2023.02.28
+- Confirmed works with 6.12 beta 18 (@kubedzero)
+- VMWare Tools v12.1.0
+- Creating `/usr/lib64/libffi.so.6` linked to `ln -s /usr/lib64/libffi.so.8` as in the previous plugin release
 
 ###2022.11.18
 - Confirmed works with 6.11.4
@@ -392,6 +397,11 @@ if 	[ $KERNEL = "4.18.20-unRAID" ]; then
 	elif [ $KERNEL = "5.19.9-Unraid" ] || [ $KERNEL = "5.19.14-Unraid" ] || [ $KERNEL = "5.19.17-Unraid" ]; then
 		OVTNAME=open_vm_tools-12.1.0-202208241430.tgz
 	    
+	## 6.12.x
+	elif [ $KERNEL = "6.1.12-Unraid" ]; then
+		OVTNAME=open_vm_tools-12.1.0-202208241430.tgz
+
+
 	else
 		echo ""
 		echo ""
@@ -437,7 +447,7 @@ if [ $KERNEL = "5.19.9-Unraid" ] || [ $KERNEL = "5.19.14-Unraid" ]; then
 	ln -s /usr/lib64/libffi.so.7 /usr/lib64/libffi.so.6
 	OVTPKG=$(ls /boot/config/plugins/OpenVMTools_compiled/packages/open_vm_tools-12.1.0-202208241430.tgz)
 	
-	elif [ $KERNEL = "5.19.17-Unraid" ]; then
+	elif [ $KERNEL = "5.19.17-Unraid" ] || [ $KERNEL = "6.1.12-Unraid" ]; then
 		ln -s /usr/lib64/libffi.so.8 /usr/lib64/libffi.so.6
 		OVTPKG=$(ls /boot/config/plugins/OpenVMTools_compiled/packages/open_vm_tools-12.1.0-202208241430.tgz)
 	    


### PR DESCRIPTION
I'm beta-testing Unraid 6.12 as a VM in ESXi, and updated this plugin to recognize and install under the new kernel. I followed the existing patterns of recognizing the kernel and installing the workarounds, and updated the plugin release and changelog accordingly. 

This is the fresh install log:

```
plugin: installing: openVMTools_compiled.plg
Executing hook script: pre_plugin_checks
plugin: downloading: openVMTools_compiled.plg ... done

Executing hook script: pre_plugin_checks

Kernel Version: 6.1.12-Unraid



+==============================================================================
| Installing new package /boot/config/plugins/openVMTools_compiled/packages/libdnet-1.12-x86_64-6cf.txz
+==============================================================================

Verifying package libdnet-1.12-x86_64-6cf.txz.
Installing package libdnet-1.12-x86_64-6cf.txz:
PACKAGE DESCRIPTION:
# libdnet
#
# libdnet provides a simplified, portable interface to several
# low-level networking routines, including
#
Executing install script for libdnet-1.12-x86_64-6cf.txz.
Package libdnet-1.12-x86_64-6cf.txz installed.

+==============================================================================
| Installing new package /boot/config/plugins/OpenVMTools_compiled/packages/open_vm_tools-12.1.0-202208241430.tgz
+==============================================================================

Verifying package open_vm_tools-12.1.0-202208241430.tgz.
Installing package open_vm_tools-12.1.0-202208241430.tgz:
PACKAGE DESCRIPTION:
Executing install script for open_vm_tools-12.1.0-202208241430.tgz.
Package open_vm_tools-12.1.0-202208241430.tgz installed.
Starting VMWare Tools Daemon.


-----------------------------------------------------------
Plugin openVMTools_compiled is installed.
Plugin Version: 2023.02.28
VMWare Tools Version: 12.1.0.37487 (build-20219665)
-----------------------------------------------------------


plugin: openVMTools_compiled.plg installed
Executing hook script: post_plugin_checks
```

I also confirmed that it stays installed on a reboot. I also confirmed that ESXi now has control over the VM to shut down safely. 